### PR TITLE
renamed `ownerHash` to `hoodieId`

### DIFF
--- a/lib/user_account.js
+++ b/lib/user_account.js
@@ -55,9 +55,9 @@ module.exports = function (hoodie) {
     var typeAndUsername = userObject.name.split(/\//)
     var type = typeAndUsername[0];
     var username = typeAndUsername[1];
-    var dbName = 'user/' + userObject.ownerHash;
+    var dbName = 'user/' + userObject.hoodieId;
 
-    // TODO: assure that the ownerHash does not exist yet.
+    // TODO: assure that the hoodieId does not exist yet.
 
     // for now, we confirm new user / anonymous_user accounts right away.
     // We plan to add settings for that though.
@@ -97,14 +97,14 @@ module.exports = function (hoodie) {
   }
 
   function confirmUser(type, userObject, callback) {
-    var readRole = 'hoodie:read:user/' + userObject.ownerHash;
-    var writeRole = 'hoodie:write:user/' + userObject.ownerHash;
-    var roles = [userObject.ownerHash, 'confirmed', readRole, writeRole].concat(userObject.roles);
+    var readRole = 'hoodie:read:user/' + userObject.hoodieId;
+    var writeRole = 'hoodie:write:user/' + userObject.hoodieId;
+    var roles = [userObject.hoodieId, 'confirmed', readRole, writeRole].concat(userObject.roles);
     hoodie.account.update(type, userObject.id, {roles: roles}, callback);
   }
 
   function handleUserDestroy(userObject) {
-    var dbName = 'user/' + userObject.ownerHash;
+    var dbName = 'user/' + userObject.hoodieId;
     hoodie.database.remove(dbName, function(error) {
       if (error) {
         console.log("Could not drop database %s", dbName)


### PR DESCRIPTION
Reason is that the new frontend method `hoodie.id()`,
that replaces `hoodie.account.ownerHash`.

To be merged together with https://github.com/hoodiehq/hoodie.js/pull/199
