### PR TITLE
Fix case where user tries to rename account to the current name.

### DIFF
--- a/lib/username_change.js
+++ b/lib/username_change.js
@@ -21,6 +21,7 @@ module.exports = function (hoodie) {
     if (oldUserObject.id == oldUserObject.$newUsername) {
       // user tries to change name to current name.
       // ignore request, delete username change doc
+      delete oldUserObject.$newUsername;
       hoodie.account.update('user', oldUserObject.id, oldUserObject, function(error) {
         if (error) {
           console.log('could not remove $newUsername object from %s', oldUserObject.id);


### PR DESCRIPTION
Prior to this patch, the changing of the username to the same
username fails, because the worker here expects that no doc
exists in _users with the target name.

This patch addresses this by deleting the `$newUsername`
property from the user doc and otherwise ignores the request.

The user-intent is already fulfilled.

This could probably also caught in the frontend.
