### PR TITLE
Handle user account confirmation properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,12 +10,28 @@ var signUp = require('./lib/signup');
 var utils = require('./lib/utils');
 
 
+var sources = [];
+
 module.exports = function (hoodie, callback) {
+
+  /**
+  * Adds a database to the pool of task event sources
+  * Makes sure it only happens once per database
+  * Maybe move the dedupe logic to hoodie-plugins-manager
+  */
+  var addSource = function addSource(doc) {
+    var dbName = utils.userDB(doc);
+
+    if(sources.indexOf(dbName) === -1) {
+      // not a source yet
+      hoodie.task.addSource(dbName);
+      sources.push(dbName);
+    }
+  };
 
   /**
    * Event handlers
    */
-
   function userChange(doc) {
     if (doc.$error) {
       // don't do any further processing to user docs with $error
@@ -27,10 +43,10 @@ module.exports = function (hoodie, callback) {
     else if (doc.$newUsername) {
       changeUsername(hoodie, doc);
     }
-    else if (!signUp.isConfirmed(doc)) {
+    else if (!signUp.isConfirmed(doc) && !signUp.isUnconfirmed(doc)) {
       signUp(hoodie, doc);
     } else {
-      hoodie.task.addSource(utils.userDB(doc));
+      addSource(doc);
     }
   }
 

--- a/lib/signup.js
+++ b/lib/signup.js
@@ -22,6 +22,13 @@ var exports = module.exports = function (hoodie, doc) {
 
 exports.isConfirmed = utils.hasRole('confirmed');
 
+
+/**
+ * Returns true if user as unconfirmed role, false otherwise
+ */
+
+exports.isUnconfirmed = utils.hasRole('unconfirmed');
+
 /**
  * Create user's personal database and grants them read/write access
  */
@@ -81,6 +88,8 @@ exports.confirmUser = function (hoodie, doc, callback) {
 
     if(allowConfirm || isAnonymousUser(doc)) {
       roles.push('confirmed');
+    } else {
+      roles.push('unconfirmed');
     }
 
     var buildRole = function(prefix, user, database) {


### PR DESCRIPTION
Now, if any plugin that returns false on its `plugin.user.confirm`
hook, we assign the role `unconfirmed`. The plugin is then
responsible for removing the `unconfirmed` role and adding the
`confirmed` role.